### PR TITLE
Updated README examples list to include Giphy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Matrix room: [#maubot:maunium.net](https://matrix.to/#/#maubot:maunium.net)
 * [echo](https://github.com/maubot/echo) - A bot that echoes pings and other stuff.
 * [rss](https://github.com/maubot/rss) - A bot that posts RSS feed updates to Matrix.
 * [reddit](https://github.com/TomCasavant/RedditMaubot) - A bot that condescendingly corrects a user when they enter an r/subreddit without providing a link to that subreddit
+* [giphy](https://github.com/TomCasavant/GiphyMaubot) - A bot that generates a gif (from giphy) given search terms
 
 ### Upcoming
 * dictionary - A bot to get the dictionary definitions of words.


### PR DESCRIPTION
I created the Giphy plugin (based on [Giphy For Slack](https://get.slack.help/hc/en-us/articles/204714258-Giphy-for-Slack)) using the Giphy API. It generates a random gif when a user types "!giphy" and it generates a more specific gif when a user types "!giphy word or phrase".