### PR TITLE
fix start and end positions of match in RegexArgument

### DIFF
--- a/maubot/handlers/command.py
+++ b/maubot/handlers/command.py
@@ -284,8 +284,8 @@ class RegexArgument(Argument):
             val = val.split(" ")[0]
         match = self.regex.match(val)
         if match:
-            return (orig_val[:match.pos] + orig_val[match.endpos:],
-                    match.groups() or val[match.pos:match.endpos])
+            return (orig_val[:match.start()] + orig_val[match.end():],
+                    match.groups() or val[match.start():match.end()])
         return orig_val, None
 
 


### PR DESCRIPTION
the `match.pos` and `match.endpos` are not the start and end of the matched
group but the start and end arguments passed to the `re.match()` method.

use `match.start()` and `match.end()` to find the beginning and the end of
the matched group.

see https://docs.python.org/3/library/re.html#match-objects