### PR TITLE
Make management UI aware of URL subpaths in config

### DIFF
--- a/maubot/management/frontend/src/api.js
+++ b/maubot/management/frontend/src/api.js
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-export const BASE_PATH = "/_matrix/maubot/v1"
+var BASE_PATH = "/_matrix/maubot/v1"
+
+export function setBasePath(basePath) {
+    BASE_PATH = basePath
+}
 
 function getHeaders(contentType = "application/json") {
     return {
@@ -241,8 +245,7 @@ export async function doClientAuth(server, type, username, password) {
 }
 
 export default {
-    BASE_PATH,
-    login, ping, getFeatures, remoteGetFeatures,
+    login, ping, setBasePath, getFeatures, remoteGetFeatures,
     openLogSocket,
     debugOpenFile, debugOpenFileEnabled, updateDebugOpenFileEnabled,
     getInstances, getInstance, putInstance, deleteInstance,

--- a/maubot/management/frontend/src/api.js
+++ b/maubot/management/frontend/src/api.js
@@ -245,6 +245,7 @@ export async function doClientAuth(server, type, username, password) {
 }
 
 export default {
+    BASE_PATH,
     login, ping, setBasePath, getFeatures, remoteGetFeatures,
     openLogSocket,
     debugOpenFile, debugOpenFileEnabled, updateDebugOpenFileEnabled,

--- a/maubot/management/frontend/src/api.js
+++ b/maubot/management/frontend/src/api.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-var BASE_PATH = "/_matrix/maubot/v1"
+let BASE_PATH = "/_matrix/maubot/v1"
 
 export function setBasePath(basePath) {
     BASE_PATH = basePath
@@ -245,7 +245,6 @@ export async function doClientAuth(server, type, username, password) {
 }
 
 export default {
-    BASE_PATH,
     login, ping, setBasePath, getFeatures, remoteGetFeatures,
     openLogSocket,
     debugOpenFile, debugOpenFileEnabled, updateDebugOpenFileEnabled,

--- a/maubot/management/frontend/src/pages/Main.js
+++ b/maubot/management/frontend/src/pages/Main.js
@@ -31,6 +31,7 @@ class Main extends Component {
     }
 
     async componentWillMount() {
+        await this.getBasePath()
         if (localStorage.accessToken) {
             await this.ping()
         } else {
@@ -38,6 +39,21 @@ class Main extends Component {
         }
         this.setState({ pinged: true })
     }
+
+    async getBasePath() {
+        try {
+            const resp = await fetch("./paths.json", {
+                headers: { "Content-Type": "application/json" }
+            })
+            const apiPathJson = await resp.json()
+            const apiPath = apiPathJson.api_path
+            console.log(apiPath)
+            api.setBasePath(`${apiPath}`)
+        } catch (err) {
+            console.error(err)
+        }
+    }
+
 
     async ping() {
         try {

--- a/maubot/management/frontend/src/pages/Main.js
+++ b/maubot/management/frontend/src/pages/Main.js
@@ -47,10 +47,9 @@ class Main extends Component {
             })
             const apiPathJson = await resp.json()
             const apiPath = apiPathJson.api_path
-            console.log(apiPath)
             api.setBasePath(`${apiPath}`)
         } catch (err) {
-            console.error(err)
+            console.error("Failed to get API path:", err)
         }
     }
 

--- a/maubot/management/frontend/src/pages/Main.js
+++ b/maubot/management/frontend/src/pages/Main.js
@@ -42,7 +42,7 @@ class Main extends Component {
 
     async getBasePath() {
         try {
-            const resp = await fetch("./paths.json", {
+            const resp = await fetch(process.env.PUBLIC_URL + "/paths.json", {
                 headers: { "Content-Type": "application/json" }
             })
             const apiPathJson = await resp.json()

--- a/maubot/server.py
+++ b/maubot/server.py
@@ -17,7 +17,7 @@ from typing import Tuple, Dict
 import logging
 import asyncio
 import json
-from urllib.parse import urlparse
+from yarl import URL
 
 from aiohttp import web, hdrs
 from aiohttp.abc import AbstractAccessLogger
@@ -136,9 +136,8 @@ class MaubotServer:
         public_url = self.config["server.public_url"]
         base_path = self.config["server.base_path"]
         public_url_path = ""
-        if public_url != "":
-            url_parts = urlparse(public_url)
-            public_url_path = url_parts.path.rstrip("/")
+        if public_url:
+            public_url_path = URL(public_url).path.rstrip("/")
 
         # assemble with base_path
         api_path = f"{public_url_path}{base_path}"

--- a/maubot/server.py
+++ b/maubot/server.py
@@ -16,6 +16,8 @@
 from typing import Tuple, Dict
 import logging
 import asyncio
+import json
+from urllib.parse import urlparse
 
 from aiohttp import web, hdrs
 from aiohttp.abc import AbstractAccessLogger
@@ -63,7 +65,8 @@ class MaubotServer:
 
     def get_instance_subapp(self, instance_id: str) -> Tuple[PluginWebApp, str]:
         subpath = self.config["server.plugin_base_path"] + instance_id
-        url = self.config["server.public_url"] + subpath
+        path_prefix = self.config["server.public_url_path_prefix"].rstrip("/")
+        url = self.config["server.public_url"] + path_prefix + subpath
         try:
             return self.plugin_routes[subpath], url
         except KeyError:
@@ -128,6 +131,22 @@ class MaubotServer:
                 data = stream.read()
             self.app.router.add_get(f"{ui_base}/{file}", lambda _: web.Response(body=data,
                                                                                 content_type=mime))
+
+        # also set up a resource path for the public url path prefix config
+        # cut the prefix path from public_url
+        public_url = self.config["server.public_url"]
+        base_path = self.config["server.base_path"]
+        public_url_path = ""
+        if public_url != "":
+            url_parts = urlparse(public_url)
+            public_url_path = url_parts.path.rstrip("/")
+
+        # assemble with base_path
+        api_path = f"{public_url_path}{base_path}"
+
+        path_prefix_response_body = json.dumps({"api_path": api_path.rstrip("/")})
+        self.app.router.add_get(f"{ui_base}/paths.json", lambda _: web.Response(body=path_prefix_response_body,
+                                                                                content_type="application/json"))
 
     def add_route(self, method: Method, path: PathBuilder, handler) -> None:
         self.app.router.add_route(method.value, str(path), handler)

--- a/maubot/server.py
+++ b/maubot/server.py
@@ -65,8 +65,7 @@ class MaubotServer:
 
     def get_instance_subapp(self, instance_id: str) -> Tuple[PluginWebApp, str]:
         subpath = self.config["server.plugin_base_path"] + instance_id
-        path_prefix = self.config["server.public_url_path_prefix"].rstrip("/")
-        url = self.config["server.public_url"] + path_prefix + subpath
+        url = self.config["server.public_url"] + subpath
         try:
             return self.plugin_routes[subpath], url
         except KeyError:


### PR DESCRIPTION
This is a first draft of what I'm trying to accomplish with making the management UI aware of URL subpaths that have been set in the server-side config. This is to cope with deployment scenarios where the maubot UI is not served from the root of the domain, e.g. `https://somedomain.com/somesubpath/_matrix/maubot/` instead of `https://somedomain.com/_matrix/maubot/`

Essentially, the server exposes a new endpoint "paths.json" that is hit upon the management UI initialisation cycle, and sets the `BASE_PATH` variable accordingly. The contents of the new endpoint is a json construct populated with path values calculated from the server-side config.

Points I'm not too sure about:
- [x] I made `BASE_PATH` mutable in api.js, please advise on the sanity of such change
- [x] I'm not sure of what to do with the two other hardcoded paths in setupProxy.js, I would appreciate guidance on their usage and whether it's useful to also make them subpath-aware.
- [x] The init cycle fetches `fetch("./paths.json")`. I'm aware the `.`  instead should be some form of webpack-like %PUBLIC_URL% value but I don't know how to get it there.

Fix #79 (more details about the scenario here)

Signed-off-by: Antoine Mazeas <antoine@karthanis.net>