### PR TITLE
Modify docker build to allow external permissions definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ RUN cd /frontend && yarn --prod && yarn build
 
 FROM alpine:3.11
 
-ENV UID=1337 \
-    GID=1337
-
-COPY . /opt/maubot
-COPY --from=frontend-builder /frontend/build /opt/maubot/frontend
 WORKDIR /opt/maubot
 RUN apk add --no-cache \
       py3-aiohttp \
@@ -28,10 +23,19 @@ RUN apk add --no-cache \
       py3-jinja2 \
       py3-click \
       py3-packaging \
-      py3-markdown \
-      && pip3 install -r requirements.txt feedparser dateparser langdetect python-gitlab
+      py3-markdown
+
+COPY requirements.txt /opt/maubot/requirements.txt
+
+RUN pip3 install -r requirements.txt feedparser dateparser langdetect python-gitlab
+
+COPY . /opt/maubot
+COPY --from=frontend-builder /frontend/build /opt/maubot/frontend
+
 # TODO remove pillow, magic and feedparser when maubot supports installing dependencies
 
 VOLUME /data
+VOLUME /config
+VOLUME /plugins
 
 CMD ["/opt/maubot/docker/run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,21 +1,12 @@
 #!/bin/sh
 
-function fixperms {
-    chown -R $UID:$GID /var/log /data /opt/maubot
-}
-
 cd /opt/maubot
 
-if [ ! -f /data/config.yaml ]; then
-	cp docker/example-config.yaml /data/config.yaml
-	mkdir -p /var/log /data/plugins /data/trash /data/dbs
-	echo "Config file not found. Example config copied to /data/config.yaml"
-	echo "Please modify the config file to your liking and restart the container."
-	fixperms
+if [ ! -f /config/config.yaml ]; then
+	echo "Config file not found."
 	exit
 fi
 
-mkdir -p /var/log/maubot /data/plugins /data/trash /data/dbs
-alembic -x config=/data/config.yaml upgrade head
-fixperms
-exec su-exec $UID:$GID python3 -m maubot -c /data/config.yaml -b docker/example-config.yaml
+mkdir -p /data/trash /data/dbs
+alembic -x config=/config/config.yaml upgrade head
+python3 -m maubot -c /config/config.yaml


### PR DESCRIPTION
This allows the consumer of the container to determine the user and group the app runs as for controlling the permissions of the data in the volumes

This also adds additional volumes to allow for splitting the configuration from the data.