### PR TITLE
Replace build-base with gcc and musl-dev, order alphabetically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,17 @@ ENV UID=1337 \
 COPY . /opt/maubot
 COPY --from=frontend-builder /frontend/build /opt/maubot/frontend
 WORKDIR /opt/maubot
-RUN apk add --no-cache \
+RUN apk add --no-cache --virtual .build-deps \
+      gcc \
+      musl-dev \
+      python3-dev \
+  && apk add --no-cache \
+      ca-certificates \
       py3-aiohttp \
       py3-sqlalchemy \
       py3-attrs \
       py3-bcrypt \
       py3-cffi \
-      build-base \
-      python3-dev \
-      ca-certificates \
-      su-exec \
       py3-pillow \
       py3-magic \
       py3-psycopg2 \
@@ -29,7 +30,13 @@ RUN apk add --no-cache \
       py3-click \
       py3-packaging \
       py3-markdown \
-      && pip3 install -r requirements.txt feedparser dateparser langdetect python-gitlab
+      su-exec \
+  && pip3 install -r requirements.txt \
+      dateparser \
+      feedparser \
+      langdetect \
+      python-gitlab \
+  && apk del .build-deps
 # TODO remove pillow, magic and feedparser when maubot supports installing dependencies
 
 VOLUME /data


### PR DESCRIPTION
This saves 62MB on the final image.

docker images | rg maubot
maubot-after                                        latest                             fb7acfc82a51        2 minutes ago       285MB
dock.mau.dev/maubot/maubot                          latest                             becadb62f32a        3 weeks ago         347MB