### PR TITLE
Dependancy problems with sqlalchemy Python module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mautrix>=0.8.12,<0.9
 aiohttp>=3,<4
 yarl>=1,<2
-SQLAlchemy>=1,<2
+SQLAlchemy>=1,<1.4
 alembic>=1,<2
 commonmark>=0.9,<1
 ruamel.yaml>=0.15.35,<0.17


### PR DESCRIPTION
In the newest version of the sqlalchemy 1.4.2 they replaced sqlalchemy.engine.cursor -> ResultProxy with some other stuff.
This leads to the following error:

(.venv) mau@mau maubot % python3 -m maubot
[2021-03-24 10:27:49,912] [INFO@maubot.init] Initializing maubot 0.1.0
[2021-03-24 10:27:49,912] [DEBUG@maubot.instance.zip] Preloading plugins...
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/mau/Projects/maubot/maubot/maubot/__main__.py", line 61, in <module>
    management_api = init_mgmt_api(config, loop)
  File "/Users/mau/Projects/maubot/maubot/maubot/management/api/__init__.py", line 43, in init
    importlib.import_module(f"maubot.management.api.{pkg}")
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/mau/Projects/maubot/maubot/maubot/management/api/instance_database.py", line 22, in <module>
    from sqlalchemy.engine.result import ResultProxy, RowProxy
ImportError: cannot import name 'ResultProxy' from 'sqlalchemy.engine.result' (/Users/mau/Projects/maubot/.venv/lib/python3.7/site-packages/sqlalchemy/engine/result.py)

Therefore I suggest for now to restrict the module version to <1.4