### PR TITLE
Fix crypto db not working with scheme postgresql

### DIFF
--- a/maubot/client.py
+++ b/maubot/client.py
@@ -409,7 +409,7 @@ def init(config: 'Config', loop: asyncio.AbstractEventLoop) -> Iterable[Client]:
             parsed_url = URL(db_url)
             if parsed_url.scheme == "sqlite":
                 Client.crypto_pickle_dir = config["crypto_database.pickle_dir"]
-            elif parsed_url.scheme == "postgres":
+            elif parsed_url.scheme == "postgres" or parsed_url.scheme == "postgresql":
                 if not PgCryptoStore:
                     log.warning("Default database is postgres, but asyncpg is not installed. "
                                 "Encryption will not work.")
@@ -418,7 +418,7 @@ def init(config: 'Config', loop: asyncio.AbstractEventLoop) -> Iterable[Client]:
                                                      upgrade_table=PgCryptoStore.upgrade_table)
         elif db_type == "pickle":
             Client.crypto_pickle_dir = config["crypto_database.pickle_dir"]
-        elif db_type == "postgres" and PgCryptoStore:
+        elif (db_type == "postgres" or db_type == "postgresql") and PgCryptoStore:
             Client.crypto_db = AsyncDatabase(url=config["crypto_database.postgres_uri"],
                                              upgrade_table=PgCryptoStore.upgrade_table)
         else:


### PR DESCRIPTION
The postgres:// scheme does not work in sqlalchemy 1.4 or higher.
Support for postgresql:// was added in 1.1.
I updated by config file and suddenly my encryption didn't work anymore,
which confused me quite a bit.

See: https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-3687655465c25a39b968b4f5f6e9170b