### PR TITLE
refactor PyInquirer to questionary

### DIFF
--- a/maubot/cli/cliq/cliq.py
+++ b/maubot/cli/cliq/cliq.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Union, Optional
 import functools
 
 from prompt_toolkit.validation import Validator
-from PyInquirer import prompt
+from questionary import prompt
 import click
 
 from ..base import app
@@ -48,7 +48,7 @@ def command(help: str) -> Callable[[Callable], Callable]:
                     pass
             question_list = list(questions.values())
             question_list.reverse()
-            resp = prompt(question_list, keyboard_interrupt_msg="Aborted!")
+            resp = prompt(question_list, kbi_msg="Aborted!")
             if not resp and question_list:
                 return
             kwargs = {**kwargs, **resp}
@@ -102,9 +102,9 @@ def option(short: str, long: str, message: str = None, help: str = None,
         if default is not None:
             q["default"] = default
         if required or required_unless is not None:
-            q["validator"] = Required(validator)
+            q["validate"] = Required(validator)
         elif validator:
-            q["validator"] = validator
+            q["validate"] = validator
         func.__inquirer_questions__[long[2:]] = q
         return func
 

--- a/maubot/cli/commands/build.py
+++ b/maubot/cli/commands/build.py
@@ -21,7 +21,7 @@ import os
 
 from ruamel.yaml import YAML, YAMLError
 from colorama import Fore
-from PyInquirer import prompt
+from questionary import prompt
 import click
 
 from mautrix.types import SerializerError

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ packaging>=10
 
 click>=7,<8
 colorama>=0.4,<0.5
-PyInquirer>=1,<2
+questionary>=1,<2
 jinja2>=2,<4


### PR DESCRIPTION
Resolves https://github.com/maubot/maubot/issues/122.

This is the minimum changes needed to get rid of PyInquirer and use questionary instead. I haven't thoroughly tested this but it runs and I can successfully login with `mbc login` and prompt to overwrite with `mbc build <plugin> -o test.mbp`, which are the only 2 places `PyInquirer.prompt` is currently used. Would appreciate others testing to confirm.