### PR TITLE
Docker: Makes the config file path  configurable via CONFIG environment variable

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 
+CONFIG=${CONFIG:-/data/config.yaml}
+
 function fixperms {
 	chown -R $UID:$GID /var/log /data /opt/maubot
 }
 
 function fixconfig {
 	# If the DB path is the default relative path, replace it with an absolute /data path
-	_db_url=$(yq e '.database' /data/config.yaml)
+	_db_url=$(yq e '.database' ${CONFIG})
 	if [[ _db_url == "sqlite:///maubot.db" ]]; then
-		yq e -i '.database = "sqlite:////data/maubot.db"' /data/config.yaml
+		yq e -i '.database = "sqlite:////data/maubot.db"' ${CONFIG}
 	fi
-	_log_path=$(yq e '.logging.handlers.file.filename' /data/config.yaml)
+	_log_path=$(yq e '.logging.handlers.file.filename' ${CONFIG})
 	if [[ _log_path == "./maubot.log" ]]; then
-		yq e -i '.logging.handlers.file.filename = "/var/log/maubot.log"' /data/config.yaml
+		yq e -i '.logging.handlers.file.filename = "/var/log/maubot.log"' ${CONFIG}
 	fi
 	# Set the correct resource paths
 	yq e -i '
@@ -21,26 +23,26 @@ function fixconfig {
 		.plugin_directories.load = ["/data/plugins"] |
 		.plugin_directories.trash = "/data/trash" |
 		.plugin_directories.db = "/data/dbs"
-	' /data/config.yaml
+	' ${CONFIG}
 }
 
 cd /opt/maubot
 
 mkdir -p /var/log/maubot /data/plugins /data/trash /data/dbs
 
-if [ ! -f /data/config.yaml ]; then
-	cp example-config.yaml /data/config.yaml
+if [ ! -f ${CONFIG} ]; then
+	cp example-config.yaml ${CONFIG}
 	# Apply some docker-specific adjustments to the config
-	echo "Config file not found. Example config copied to /data/config.yaml"
+	echo "Config file not found. Example config copied to ${CONFIG}"
 	echo "Please modify the config file to your liking and restart the container."
 	fixperms
 	fixconfig
 	exit
 fi
 
-alembic -x config=/data/config.yaml upgrade head
+alembic -x config=${CONFIG} upgrade head
 fixperms
 fixconfig
 mv -n /data/plugins/*.db /data/dbs/
 
-exec su-exec $UID:$GID python3 -m maubot -c /data/config.yaml
+exec su-exec $UID:$GID python3 -m maubot -c ${CONFIG}


### PR DESCRIPTION
In my deployment, I am templating the config file on startup, and so I don't want it to be persistent in the same volume as my database. To accommodate that goal, I modified `run.sh` to allow changing the default path with the `CONFIG` variable. It has a default value the same as before: `/data/config.yaml`, but you can change it by adding the environment variable to your docker run command line with `-e CONFIG=/some/path` or by using a `.env` file.

Since maubot itself already has the ability to load a config file from another location `-c PATH`, I am simply exposing this ability to the docker container initialization. 