### PR TITLE
No longer use deprecated loop parameter

### DIFF
--- a/maubot/cli/commands/logs.py
+++ b/maubot/cli/commands/logs.py
@@ -38,7 +38,7 @@ def logs(server: str, tail: int) -> None:
     global history_count
     history_count = tail
     loop = asyncio.get_event_loop()
-    future = asyncio.create_task(view_logs(server, token), loop=loop)
+    future = loop.create_task(view_logs(server, token))
     try:
         loop.run_until_complete(future)
     except KeyboardInterrupt:


### PR DESCRIPTION
Fixes #165 

If I understand correctly, the `loop` keyword argument is deprecated since python 3.8 and is removed in python 3.10.

I don't understand why this resulted in an error in 3.8 (see #165), when it's merely a deprecation (that's above my python skills).

I've tested this change on 3.8, 3.9 and 3.10 and AFAICT it behaves correctly.