### PR TITLE
Change logfile path

### DIFF
--- a/maubot/example-config.yaml
+++ b/maubot/example-config.yaml
@@ -117,7 +117,7 @@ logging:
         file:
             class: logging.handlers.RotatingFileHandler
             formatter: normal
-            filename: ./maubot.log
+            filename: ./logs/maubot.log
             maxBytes: 10485760
             backupCount: 10
         console:


### PR DESCRIPTION
Maubot's documentation suggest to create a `log` directoctory but with the former setting it was never used.