### PR TITLE
Fix must_consume_args

### DIFF
--- a/maubot/handlers/command.py
+++ b/maubot/handlers/command.py
@@ -92,6 +92,7 @@ class CommandHandler:
                 "get_name",
                 "is_command_match",
                 "require_subcommand",
+                "must_consume_args",
                 "arg_fallthrough",
                 "event_handler",
                 "event_type",


### PR DESCRIPTION
Tin. It's currently a no-op (defaults to True and changing isn't carried through).