### PR TITLE
Fix choosing SPDX license during plugin init

### DIFF
--- a/maubot/cli/util/spdx.py
+++ b/maubot/cli/util/spdx.py
@@ -36,10 +36,10 @@ def load() -> None:
 def get(id: str) -> dict[str, str]:
     if not spdx_list:
         load()
-    return spdx_list[id.lower()]
+    return spdx_list[id]
 
 
 def valid(id: str) -> bool:
     if not spdx_list:
         load()
-    return id.lower() in spdx_list
+    return id in spdx_list


### PR DESCRIPTION
The keys used to be lower case, but were changed to mixed case
in this commit:

068e268c632b90e5e4f2954f3eaf3aa9342c240c

The identfier are now used as inputted by the user.