### PR TITLE
Adding a py.typed to avoid mypy errors when importing module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setuptools.setup(
             "management/frontend/build/static/css/*",
             "management/frontend/build/static/js/*",
             "management/frontend/build/static/media/*",
+            "py.typed",
         ],
         "maubot.cli": ["res/*"],
         "maubot.standalone": ["example-config.yaml"],


### PR DESCRIPTION
This prevents errors like the following when when importing maubot and running mypy: Skipping analyzing "maubot": module is installed, but missing library stubs or py.typed marker

See
https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker

Fixes #196 