### PR TITLE
reformat readme to simplify plugins sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,43 +49,11 @@ The plugin wishlist lives at <https://github.com/maubot/plugin-wishlist/issues>.
 * [songwhip](https://github.com/maubot/songwhip) - A bot to post Songwhip links.
 * [manhole](https://github.com/maubot/manhole) - A plugin that lets you access a Python shell inside maubot.
 
-### 3rd party plugins
-* [subreddit linkifier](https://github.com/TomCasavant/RedditMaubot) - A bot that condescendingly corrects a user when they enter an r/subreddit without providing a link to that subreddit
-* [giphy](https://github.com/TomCasavant/GiphyMaubot) - A bot that generates a gif (from giphy) given search terms
-* [trump](https://github.com/jeffcasavant/MaubotTrumpTweet) - A bot that generates a Trump tweet with the given content
-* [poll](https://github.com/TomCasavant/PollMaubot) - A bot that will create a simple poll for users in a room
-* [urban](https://github.com/dvdgsng/UrbanMaubot) - A bot that fetches definitions from [Urban Dictionary](https://www.urbandictionary.com/).
-* [twilio](https://github.com/jeffcasavant/MaubotTwilio) - Maubot-based SMS bridge
-* [tmdb](https://codeberg.org/lomion/tmdb-bot) - A bot that posts information about movies fetched from TheMovieDB.org.
-* [invite](https://github.com/williamkray/maubot-invite) - A bot to generate invitation tokens from [matrix-registration](https://github.com/ZerataX/matrix-registration)
-* [wolframalpha](https://github.com/ggogel/WolframAlphaMaubot) - A bot that allows requesting information from [WolframAlpha](https://www.wolframalpha.com/).
-* †[pingcheck](https://edugit.org/nik/maubot-pingcheck) - A bot to ping the echo bot and send rtt to Icinga passive check
-* [ticker](https://github.com/williamkray/maubot-ticker) - A bot to return financial data about a stock or cryptocurrency.
-* [weather](https://github.com/kellya/maubot-weather) - A bot to get the weather from wttr.in and return a single line of text for the location specified
-* †[youtube previewer](https://github.com/ggogel/YoutubePreviewMaubot) - A bot that responds to a YouTube link with the video title and thumbnail.
-* †[reddit previewer](https://github.com/ggogel/RedditPreviewMaubot) - A bot that responds to a link of a reddit post with the sub name and title. If available, uploads the image or video.
-* [pocket](https://github.com/jaywink/maubot-pocket) - A bot integrating with Pocket to fetch articles and archive them.
-* [alternatingcaps](https://github.com/rom4nik/maubot-alternatingcaps) - A bot repeating last message using aLtErNaTiNg cApS.
-* [metric](https://github.com/edwardsdean/maubot_metric_bot) - A bot that will reply to a message that contains imperial units and replace them with metric units.
-* [urlpreview](https://github.com/coffeebank/coffee-maubot/tree/master/urlpreview) - A bot that responds to links with a link preview embed, using Matrix API to fetch meta tags.
-* [autoreply](https://github.com/babolivier/maubot-autoreply) - A bot that sends automated replies when you're away, and shows you a summary of missed messages when you come back.
-* [alertbot](https://github.com/moan0s/alertbot) - A bot that recives monitoring alerts via alertmanager and forwards them to a matrix room.
-* [hasswebhookbot](https://github.com/v411e/hasswebhookbot) - A bot receiving webhooks from [Home Assistant](https://github.com/home-assistant).
-* [ovgumensabot](https://github.com/v411e/ovgumensabot) - A bot that automatically sends meals from OvGU canteen every day.
-* †[token](https://github.com/yoxcu/maubot-token) - A maubot to create and manage your synapse user registration tokens.
-* [redactbot](https://gitlab.com/sspaeth/redactbot) - A bot that immediately redacts any posted file (except for whitelisted types).
-* [join](https://github.com/williamkray/maubot-join) - A plugin that restricts who can convince your bot to join new rooms to certain users.
-* [create-room](https://github.com/williamkray/maubot-createroom) - A plugin that creates new rooms and automatically
-  sets them to be part of a private Matrix Space.
-* [welcome](https://github.com/williamkray/maubot-welcome) - A plugin that greets new people with a configurable message when they join a room.
-* [activity tracker](https://github.com/williamkray/maubot-kickbot) - A plugin that minimally tracks user activity
-  within a space. Useful for kicking inactive users from a private community.
-* [random subreddit post](https://github.com/williamkray/maubot-reddit) - A plugin that returns a random post from a
-  given subreddit.
-
-† Uses a synchronous library which can block the whole maubot process (e.g. requests instead of aiohttp)
-
 ### Deprecated/unmaintained plugins
 * [jesaribot](https://github.com/maubot/jesaribot) - A simple bot that replies with an image when you say "jesari".
   * Superseded by reactbot
 * [gitea](https://github.com/saces/maugitea) - A Gitea client and webhook receiver.
+
+### 3rd party plugins
+While not a comprehensive list, https://maubotplugins.mssj.me aims to be a crowd-sourced list of plugins from around the
+web.


### PR DESCRIPTION
i've put together a separate website (and git repository) for people to contribute plugins to a list. it provides a simple searchable interface for a friendly experience, and my aim is to take some of the burden off your shoulders with regard to keeping your README up to date with new additions and additional PRs that aren't actually related to the maubot codebase. 