### PR TITLE
Fix required=True not accounted for for simple argument

### DIFF
--- a/maubot/handlers/command.py
+++ b/maubot/handlers/command.py
@@ -403,6 +403,8 @@ class CustomArgument(Argument):
 
 class SimpleArgument(Argument):
     def match(self, val: str, **kwargs) -> Tuple[str, Any]:
+        if not val:
+            return "", None
         if self.pass_raw:
             return "", val
         res = re.split(r"\s", val, 1)[0]


### PR DESCRIPTION
`CommandHandler.__parse_args__` checks for the None value returned Argument.match() to possibly raise if no value got passed to a *required* argument. Unfortunately, `SimpleArgument.match()` never returns None but would instead return the empty string it receives (which is being stripped by the caller, `__parse_args__()`). As such, `@argument(..., required=True)` does not work and silently passes an empty string to the command handler.

We fix this returning None early in `SimpleArgument.match()` when it receives an empty string value.