### PR TITLE
Add APScheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,9 @@ RUN apk add --no-cache \
         py3-feedparser \
         py3-dateutil \
         py3-lxml \
-        py3-semver
-# TODO remove pillow, magic, feedparser, lxml, gitlab and semver when maubot supports installing dependencies
+        py3-semver \
+        py3-apscheduler
+# TODO remove pillow, magic, feedparser, lxml, gitlab, apscheduler, and semver when maubot supports installing dependencies
 
 COPY requirements.txt /opt/maubot/requirements.txt
 COPY optional-requirements.txt /opt/maubot/optional-requirements.txt


### PR DESCRIPTION
[This alternative reminder plugin](https://github.com/MxMarx/reminder) needs APScheduler. APScheduler is fairly lightweight, and could potentially be useful for other bots that have scheduled tasks.