### PR TITLE
Allow the pickle_key to be configured via the config file.

### DIFF
--- a/maubot/__main__.py
+++ b/maubot/__main__.py
@@ -43,6 +43,7 @@ class Maubot(Program):
     server: MaubotServer
     db: Database
     crypto_db: Database | None
+    crypto_db_pickle_key: str = "mau.crypto"
     plugin_postgres_db: PostgresDatabase | None
     state_store: PgStateStore
 
@@ -73,6 +74,7 @@ class Maubot(Program):
         )
 
     def prepare_db(self) -> None:
+        self.crypto_db_pickle_key = self.config["crypto_db_pickle_key"]
         self.db = Database.create(
             self.config["database"],
             upgrade_table=upgrade_table,

--- a/maubot/client.py
+++ b/maubot/client.py
@@ -186,7 +186,7 @@ class Client(DBClient):
 
     def _prepare_crypto(self) -> None:
         self.crypto_store = PgCryptoStore(
-            account_id=self.id, pickle_key="mau.crypto", db=self.maubot.crypto_db
+            account_id=self.id, pickle_key=self.maubot.crypto_db_pickle_key, db=self.maubot.crypto_db
         )
         self.crypto = OlmMachine(
             self.client,

--- a/maubot/client.py
+++ b/maubot/client.py
@@ -186,7 +186,9 @@ class Client(DBClient):
 
     def _prepare_crypto(self) -> None:
         self.crypto_store = PgCryptoStore(
-            account_id=self.id, pickle_key=self.maubot.crypto_db_pickle_key, db=self.maubot.crypto_db
+            account_id=self.id,
+            pickle_key=self.maubot.crypto_db_pickle_key,
+            db=self.maubot.crypto_db
         )
         self.crypto = OlmMachine(
             self.client,

--- a/maubot/client.py
+++ b/maubot/client.py
@@ -188,7 +188,7 @@ class Client(DBClient):
         self.crypto_store = PgCryptoStore(
             account_id=self.id,
             pickle_key=self.maubot.crypto_db_pickle_key,
-            db=self.maubot.crypto_db
+            db=self.maubot.crypto_db,
         )
         self.crypto = OlmMachine(
             self.client,

--- a/maubot/config.py
+++ b/maubot/config.py
@@ -43,6 +43,7 @@ class Config(BaseFileConfig):
                 base["crypto_database"] = self["crypto_database.postgres_uri"]
         else:
             copy("crypto_database")
+        copy("crypto_db_pickle_key")
         copy("plugin_directories.upload")
         copy("plugin_directories.load")
         copy("plugin_directories.trash")

--- a/maubot/example-config.yaml
+++ b/maubot/example-config.yaml
@@ -3,6 +3,7 @@
 #   SQLite:   sqlite:filename.db
 #   Postgres: postgresql://username:password@hostname/dbname
 database: sqlite:maubot.db
+crypto_db_pickle_key: mau.crypto
 
 # Separate database URL for the crypto database. "default" means use the same database as above.
 crypto_database: default

--- a/maubot/standalone/__main__.py
+++ b/maubot/standalone/__main__.py
@@ -147,7 +147,7 @@ if device_id and not OlmMachine:
         exc_info=crypto_import_error,
     )
 elif device_id:
-    crypto_store = PgCryptoStore(account_id=user_id, pickle_key="mau.crypto", db=db)
+    crypto_store = PgCryptoStore(account_id=user_id, pickle_key=config["crypto_db_pickle_key"], db=db)
     state_store = PgCryptoStateStore(db)
 
 bot_config = None

--- a/maubot/standalone/__main__.py
+++ b/maubot/standalone/__main__.py
@@ -147,7 +147,9 @@ if device_id and not OlmMachine:
         exc_info=crypto_import_error,
     )
 elif device_id:
-    crypto_store = PgCryptoStore(account_id=user_id, pickle_key=config["crypto_db_pickle_key"], db=db)
+    crypto_store = PgCryptoStore(
+        account_id=user_id, pickle_key=config["crypto_db_pickle_key"], db=db
+    )
     state_store = PgCryptoStateStore(db)
 
 bot_config = None

--- a/maubot/standalone/config.py
+++ b/maubot/standalone/config.py
@@ -47,6 +47,7 @@ class Config(BaseFileConfig):
             copy("server.public_url")
         copy("database")
         copy("database_opts")
+        copy("crypto_db_pickle_key")
         if "plugin_config" in base:
             copy("plugin_config")
         copy("logging")

--- a/maubot/standalone/example-config.yaml
+++ b/maubot/standalone/example-config.yaml
@@ -43,6 +43,7 @@ server:
 # The database for the plugin. Used for plugin data, the sync token and e2ee data (if enabled).
 # SQLite and Postgres are supported.
 database: sqlite:bot.db
+crypto_db_pickle_key: mau.crypto
 
 # Additional arguments for asyncpg.create_pool() or sqlite3.connect()
 # https://magicstack.github.io/asyncpg/current/api/index.html#asyncpg.pool.create_pool


### PR DESCRIPTION
Added a new entry (crypto_db_pickle_key) into

1. maubot/example-config.yaml and
2. maubot/standalone/example-config.yaml

So that the pickle_key used to encrypt the account in the database can be changed arbitrarily. (as opposed to being hardcoded at `mau.crypto`)

I tested it to the best of my ability... I ran both the main version and the standalone version, and verified that I could decrypt the account with `account = OlmAccount.from_pickle(account, passphrase=pickle_key, shared=shared)` with the randomly chosen password... (And verified that it fails when I enter the wrong password)..