### PR TITLE
Support custom licenses

### DIFF
--- a/maubot/cli/commands/init.py
+++ b/maubot/cli/commands/init.py
@@ -88,7 +88,10 @@ def init(name: str, id: str, version: Version, license: str, config: bool) -> No
         file.write(meta)
     if license:
         with open("LICENSE", "w") as file:
-            file.write(spdx.get(license)["licenseText"])
+            if license.startswith("LicenseRef-"):
+                file.write("** You must include the license text here **")
+            else:
+                file.write(spdx.get(license)["licenseText"])
     if not os.path.isdir(name):
         os.mkdir(name)
     mod = mod_template.render(config=config, name=main_class)

--- a/maubot/cli/util/spdx.py
+++ b/maubot/cli/util/spdx.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+import re
 import zipfile
 
 import pkg_resources
@@ -42,4 +43,5 @@ def get(id: str) -> dict[str, str]:
 def valid(id: str) -> bool:
     if not spdx_list:
         load()
-    return id in spdx_list
+    custom_license = re.compile('LicenseRef-[a-zA-Z0-9.-]*$')
+    return bool(custom_license.match(id)) or id in spdx_list


### PR DESCRIPTION
SPDX support custom licenses by the LicenseRef-[idString] identifier, as described at annex B.3 simple license expressions

https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/#simple-license-expressions

It has also previous adopted by python itself at PEP-639:

https://peps.python.org/pep-0639/