### PR TITLE
fix: building plugins on Windows where HOME isn't available sometimes

### DIFF
--- a/maubot/cli/config.py
+++ b/maubot/cli/config.py
@@ -26,7 +26,13 @@ config: dict[str, Any] = {
     "aliases": {},
     "default_server": None,
 }
-configdir = os.environ.get("XDG_CONFIG_HOME", os.path.join(os.environ.get("HOME"), ".config"))
+home_dir = os.environ.get("HOME") or os.environ.get("USERPROFILE")
+if home_dir is None:
+    raise EnvironmentError(
+        "Neither HOME nor USERPROFILE environment variables are set."
+    )
+
+configdir = os.environ.get("XDG_CONFIG_HOME", os.path.join(home_dir, ".config"))
 
 
 def get_default_server() -> tuple[str | None, str | None]:


### PR DESCRIPTION
`os.environ.get("HOME")` is returning None, leading to the TypeError when trying to join it with .config. This issue typically arises on Windows systems, where the HOME environment variable may not be set by default, unlike on Linux-based systems. This PR should mitigate that when building on Windows systems. 